### PR TITLE
build(travis): explicit install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
   email: true
 node_js:
   - '8'
+install: npm install
 before_install:
   - npm install -g npm@5
   - npm install -g greenkeeper-lockfile@1


### PR DESCRIPTION
Specify npm install as install step as default npm ci install step is failing greenkeeper-lockfile builds due to out-of-date package-lock.json file