### PR TITLE
Fix getMe Information on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const userDetails = await client.getUser('some user id');
 Get details for user associated with API key
 
 ```javascript
-const myUserDetails = await client.getMyUser();
+const myUserDetails = await client.getMe();
 ```
 
 ### `getTeams`


### PR DESCRIPTION
When I tried to use this function I get this error:

`UnhandledPromiseRejectionWarning: TypeError: client.getMyUser is not a function`.

I search by "getMyUser" on code base I did not find it. So I think that the correct function is `getMe` instead of `getMyUSer