### PR TITLE
fix 401 error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5220,12 +5220,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
+      "version": "0.20.0-0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0-0.tgz",
+      "integrity": "sha512-FdJxKL7EntcZprZvis5kDQ13aXVG1Fn022tG45wvP7/ILZ074pedaFLkI4uQgfRCrxwkzXeLnL3GOvXo6gqitg==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "babel-core": {
@@ -8488,24 +8487,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
+      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5223,6 +5223,7 @@
       "version": "0.20.0-0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0-0.tgz",
       "integrity": "sha512-FdJxKL7EntcZprZvis5kDQ13aXVG1Fn022tG45wvP7/ILZ074pedaFLkI4uQgfRCrxwkzXeLnL3GOvXo6gqitg==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -8489,7 +8490,8 @@
     "follow-redirects": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
-      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg=="
+      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "axios": "^0.20.0-0"
+    "axios": "^0.20.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "axios": "^0.20.0-0"
   },
   "peerDependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.20.0-0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
     "integration-test": "BABEL_ENV=test jest src/ -c jest.config.integration.js",
     "travis-deploy-once": "npx travis-deploy-once"
   },
-  "dependencies": {
-    "axios": "^0.20.0-0"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "axios": "^0.20.0-0"
   },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@rollup/plugin-babel": "^5.0.3",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.0.1",
+    "axios": "^0.20.0-0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^26.0.1",
     "codecov": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "axios": "^0.20.0"
+    "axios": "next"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "integration-test": "BABEL_ENV=test jest src/ -c jest.config.integration.js",
     "travis-deploy-once": "npx travis-deploy-once"
   },
-  "dependencies": {},
+  "dependencies": {
+    "axios": "^0.20.0-0"
+  },
   "peerDependencies": {
     "axios": "^0.19.0"
   },
@@ -60,7 +62,6 @@
     "@rollup/plugin-babel": "^5.0.3",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.0.1",
-    "axios": "^0.19.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^26.0.1",
     "codecov": "^3.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,11 @@ class WakaTimeClient {
     this.apiKey = apiKey;
     this.axiosConfiguration = axios.create({
       baseURL: 'https://wakatime.com/api/v1/',
-      // Base-64 encode the API Key
       // https://wakatime.com/developers#introduction
-      headers: { Authorization: `Basic ${Buffer.from(this.apiKey).toString('base64')}` },
+      // use URL parameter
+      params: {
+        api_key: apiKey,
+      },
     });
   }
 


### PR DESCRIPTION
see [#95](https://github.com/jaebradley/wakatime-client/issues/95).

Fix 401 error and use latest version(0.20.0-0) of `axios` to enable to setup  `params` in `axios.create` for later use.

Use `params` instead of `headers` to fix 401 error.
```diff
--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,11 @@ class WakaTimeClient {
     this.apiKey = apiKey;
     this.axiosConfiguration = axios.create({
       baseURL: 'https://wakatime.com/api/v1/',
-      // Base-64 encode the API Key
       // https://wakatime.com/developers#introduction
-      headers: { Authorization: `Basic ${Buffer.from(this.apiKey).toString('base64')}` },
+      // use URL parameter
+      params: {
+        api_key: apiKey,
+      },
     });
   }
```

According to axios‘ [pull 2844](https://github.com/axios/axios/pull/2844),  there is a problem with axios  < 0.20.0-0 that led the `params` to undefined. To fix that, I upgrade the axios from `0.19.2` to `0.20.0-0` which solved such issue.



